### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::SES [![Build Status](https://travis-ci.org/SpringMT/fluent-plugin-ses.png)](https://travis-ci.org/SpringMT/fluent-plugin-ses)
+# Fluent::Plugin::SES, a plugin for [Fluentd](http://fluentd.org) [![Build Status](https://travis-ci.org/SpringMT/fluent-plugin-ses.png)](https://travis-ci.org/SpringMT/fluent-plugin-ses)
 
 Fluent output plugin for AWS SES
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
