### PR TITLE
Adopt gem dependency and introduce RSpec3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
 matrix:
   allow_failures:
     - rvm: 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ group :test do
   gem 'rspec'
   gem 'rspec-core'
   gem 'rake'
+  gem 'test-unit'
 end
 

--- a/fluent-plugin-ses.gemspec
+++ b/fluent-plugin-ses.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "fluent-mixin-plaintextformatter"
-  gem.add_runtime_dependency "aws-sdk"
+  gem.add_runtime_dependency "aws-sdk-v1"
   gem.description = <<description
 Fluent output plugin for AWS SES
 description

--- a/lib/fluent/plugin/out_ses.rb
+++ b/lib/fluent/plugin/out_ses.rb
@@ -8,7 +8,7 @@ module Fluent
 
     def initialize
       super
-      require 'aws-sdk'
+      require 'aws-sdk-v1'
     end
 
     include SetTagKeyMixin

--- a/spec/out_ses_spec.rb
+++ b/spec/out_ses_spec.rb
@@ -46,8 +46,8 @@ describe Fluent::SESOutput do
   describe :configure do
     before do
       dummy_object = (Class.new { define_method :verified? do; true end }).new
-      AWS::SimpleEmailService.any_instance.stub(:identities).and_return({'spring' => dummy_object})
-      AWS::SimpleEmailService.any_instance.stub_chain(:client, :send_email).and_return(true)
+      allow_any_instance_of(AWS::SimpleEmailService).to receive(:identities).and_return({'spring' => dummy_object})
+      allow_any_instance_of(AWS::SimpleEmailService).to receive_message_chain(:client, :send_email).and_return(true)
     end
     context 'valid' do
       it { d = create_driver }
@@ -64,7 +64,7 @@ describe Fluent::SESOutput do
     context 'invalid from mail' do
       before do
         dummy_object = (Class.new { define_method :verified? do; false end }).new
-        AWS::SimpleEmailService.any_instance.stub(:identities).and_return({'spring' => dummy_object})
+        allow_any_instance_of(AWS::SimpleEmailService).to receive(:identities).and_return({'spring' => dummy_object})
       end
       it { expect{ d = create_driver DEFAULT_CONFIG; d.run }.to raise_error(Fluent::ConfigError) }
     end
@@ -77,8 +77,8 @@ describe Fluent::SESOutput do
     context 'valid' do
       before do
         dummy_object = (Class.new { define_method :verified? do; true end }).new
-        AWS::SimpleEmailService.any_instance.stub(:identities).and_return({'spring' => dummy_object})
-        AWS::SimpleEmailService.any_instance.stub_chain(:client, :send_email).and_return(true)
+        allow_any_instance_of(AWS::SimpleEmailService).to receive(:identities).and_return({'spring' => dummy_object})
+        allow_any_instance_of(AWS::SimpleEmailService).to receive_message_chain(:client, :send_email).and_return(true)
       end
       it do
         d = create_driver

--- a/spec/out_ses_spec.rb
+++ b/spec/out_ses_spec.rb
@@ -2,7 +2,7 @@
 # encoding: UTF-8
 
 require File.dirname(__FILE__) + '/spec_helper'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 DEFAULT_CONFIG = %[
   aws_key_id  foo

--- a/spec/out_ses_spec.rb
+++ b/spec/out_ses_spec.rb
@@ -94,7 +94,7 @@ describe Fluent::SESOutput do
   describe :write do
     context 'test_write' do
       it do
-        pending 'If sending email actually, remove pending' do
+        skip 'If sending email actually, remove skip block' do
         d = create_driver TEST_CONFIG
         time = Time.parse("2013-03-19 00:00:00 UTC").to_i
         d.emit({"a" => 1}, time)


### PR DESCRIPTION
I modified to use `aws-sdk-v1` and `test-unit` gem in this plugin.
And I adopted to RSpec3 syntax with `transpec`.

If you have any objections, please feel free to reject this PR.

If this PR were to be merged, I would send another PR about `secret parameters`.
